### PR TITLE
Add React frontend to filter recipes by ingredients

### DIFF
--- a/recipe-finder-backend/Gemfile
+++ b/recipe-finder-backend/Gemfile
@@ -52,6 +52,7 @@ gem 'dotenv-rails', groups: [:development, :test]
 # gem "image_processing", "~> 1.2"
 
 gem 'progress_bar'
+gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/recipe-finder-backend/Gemfile.lock
+++ b/recipe-finder-backend/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.9)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.3)
@@ -246,6 +248,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   progress_bar
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.8)
   redis (~> 4.0)
   rspec-rails (~> 5.0)

--- a/recipe-finder-backend/config/initializers/cors.rb
+++ b/recipe-finder-backend/config/initializers/cors.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:3001'
+    resource '*',
+             headers: :any,
+             methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/recipe-finder-frontend/src/App.js
+++ b/recipe-finder-frontend/src/App.js
@@ -1,24 +1,13 @@
 import logo from './logo.svg';
 import './App.css';
+import React from 'react';
+import RecipeFilter from './components/RecipeFilter';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+      <div className="App">
+        <RecipeFilter />
+      </div>
   );
 }
 

--- a/recipe-finder-frontend/src/components/RecipeFilter.js
+++ b/recipe-finder-frontend/src/components/RecipeFilter.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const RecipeFilter = () => {
+    const [ingredients, setIngredients] = useState('');
+    const [recipes, setRecipes] = useState([]);
+
+    const handleInputChange = (event) => {
+        setIngredients(event.target.value);
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const response = await axios.get(
+                `http://localhost:3000/recipes`,
+                {
+                    params: {
+                        ingredients: ingredients,
+                    },
+                }
+            );
+            setRecipes(response.data);
+        } catch (error) {
+            console.error('Error fetching recipes:', error);
+        }
+    };
+
+    return (
+        <div>
+            <h1>Recipe Finder</h1>
+            <form onSubmit={handleSubmit}>
+                <input
+                    type="text"
+                    placeholder="Enter ingredients, separated by commas"
+                    value={ingredients}
+                    onChange={handleInputChange}
+                />
+                <button type="submit">Find Recipes</button>
+            </form>
+            <div>
+                {recipes.length > 0 ? (
+                    <ul>
+                        {recipes.map((recipe) => (
+                            <li key={recipe.id}>
+                                <h2>{recipe.title}</h2>
+                                <p>Cook Time: {recipe.cook_time} minutes</p>
+                                <p>Prep Time: {recipe.prep_time} minutes</p>
+                                <p>Ratings: {recipe.ratings}</p>
+                                <img src={recipe.image} alt={recipe.title} />
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p>No recipes found</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default RecipeFilter;


### PR DESCRIPTION
### Overview

This pull request adds a React frontend to the Rails application, enabling users to input ingredients and fetch recipes that contain those ingredients.

### Details

1. **React App**:
   - Created a new React app in the `recipe-finder-frontend` directory.
   - Implemented the `RecipeFilter` component to allow users to input ingredients and fetch matching recipes.
   - Configured Axios for making HTTP requests to the Rails backend.

2. **CORS Configuration**:
   - Added the `rack-cors` gem to the Rails backend.
   - Configured CORS to allow requests from `http://localhost:3000`.

3. **Integration**:
   - React frontend fetches recipes from the Rails backend using the query parameter `ingredients`.

### How to Test

1. Run migrations:
   ```bash
   rails db:migrate

2. Start the Rails server:
   ```bash
   rails server

3. Navigate to the recipe-finder-frontend directory and start the React development server:
   ```bash
   cd recipe-finder-frontend
   npm run start-frontend

4. Open http://localhost:3000 in your browser and use the input field to enter ingredients, separated by commas, and fetch matching recipes.
